### PR TITLE
Fix LinkType enum handler

### DIFF
--- a/src/main/java/mapper/handler/LinkTypeHandler.java
+++ b/src/main/java/mapper/handler/LinkTypeHandler.java
@@ -11,32 +11,33 @@ import org.apache.ibatis.type.MappedJdbcTypes;
 import org.apache.ibatis.type.MappedTypes;
 
 import domain.AttachLink.LinkType;
-import domain.en.CategoryStatus;
 
 @MappedTypes(LinkType.class)
 @MappedJdbcTypes(JdbcType.VARCHAR)
-public class LinkTypeHandler extends BaseTypeHandler<CategoryStatus>{
+public class LinkTypeHandler extends BaseTypeHandler<LinkType>{
 
 	@Override
-	public void setNonNullParameter(PreparedStatement ps, int i, CategoryStatus parameter, JdbcType jdbcType)
-			throws SQLException {
-		ps.setString(i, parameter.name());
-	}
+       public void setNonNullParameter(PreparedStatement ps, int i, LinkType parameter, JdbcType jdbcType)
+                       throws SQLException {
+               ps.setString(i, parameter.name());
+       }
 
-	@Override
-	public CategoryStatus getNullableResult(ResultSet rs, String columnName) throws SQLException {
-		return CategoryStatus.valueOf(rs.getString(columnName));
-	}
+       @Override
+       public LinkType getNullableResult(ResultSet rs, String columnName) throws SQLException {
+               String value = rs.getString(columnName);
+               return value != null ? LinkType.valueOf(value) : null;
+       }
 
-	@Override
-	public CategoryStatus getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-		return CategoryStatus.valueOf(rs.getString(columnIndex));
-	}
+       @Override
+       public LinkType getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+               String value = rs.getString(columnIndex);
+               return value != null ? LinkType.valueOf(value) : null;
+       }
 
-	@Override
-	public CategoryStatus getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-		// TODO Auto-generated method stub
-		return CategoryStatus.valueOf(cs.getString(columnIndex));
-	}
+       @Override
+       public LinkType getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+               String value = cs.getString(columnIndex);
+               return value != null ? LinkType.valueOf(value) : null;
+       }
 	
 }


### PR DESCRIPTION
## Summary
- fix LinkTypeHandler to use AttachLink.LinkType instead of CategoryStatus

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68834a4f6ab8832e88577602483692a7